### PR TITLE
Make regex for input/output identifiers clear and uniform

### DIFF
--- a/APIs/ChannelMappingAPI.raml
+++ b/APIs/ChannelMappingAPI.raml
@@ -86,6 +86,7 @@ documentation:
       200:
         body:
           example: !include ../examples/inputs/inputs-root-get-200.json
+          type: !include schemas/input-output-root-schema.json
   /{inputName}:
     get:
       responses:
@@ -129,6 +130,7 @@ documentation:
       200:
         body:
           example: !include ../examples/outputs/output-root-get-200.json
+          type: !include schemas/input-output-root-schema.json
       404:
         description: Returned when the requested resource does not exist
   /{outputName}:

--- a/APIs/schemas/input-output-root-schema.json
+++ b/APIs/schemas/input-output-root-schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "List of inputs/outputs",
+  "title": "Input/Outputs root resource",
+  "items": {
+    "type": "string",
+    "pattern": "^[a-z A-Z 0-9 \\- _]+/$"
+  }
+}

--- a/APIs/schemas/input-output-root-schema.json
+++ b/APIs/schemas/input-output-root-schema.json
@@ -5,6 +5,6 @@
   "title": "Input/Outputs root resource",
   "items": {
     "type": "string",
-    "pattern": "^[a-z A-Z 0-9 \\- _]+/$"
+    "pattern": "^[a-zA-Z0-9\\-_]+/$"
   }
 }

--- a/APIs/schemas/io-response-schema.json
+++ b/APIs/schemas/io-response-schema.json
@@ -11,7 +11,7 @@
     "inputs":{
       "type": "object",
       "patternProperties": {
-        "^[a-z A-Z 0-9 \\- _]+$":{
+        "^[a-zA-Z0-9\\-_]+$":{
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -31,7 +31,7 @@
     "outputs":{
       "type": "object",
       "patternProperties": {
-        "^[a-z A-Z 0-9 \\- _]+$":{
+        "^[a-zA-Z0-9\\-_]+$":{
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/APIs/schemas/io-response-schema.json
+++ b/APIs/schemas/io-response-schema.json
@@ -11,7 +11,7 @@
     "inputs":{
       "type": "object",
       "patternProperties": {
-        "^[0-9]+:[0-9]+$":{
+        "^[a-z A-Z 0-9 \\- _]+$":{
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -31,7 +31,7 @@
     "outputs":{
       "type": "object",
       "patternProperties": {
-        "^[0-9]+:[0-9]+$":{
+        "^[a-z A-Z 0-9 \\- _]+$":{
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/APIs/schemas/map-tables-request-schema.json
+++ b/APIs/schemas/map-tables-request-schema.json
@@ -10,7 +10,7 @@
     },
     "map":{
       "patternProperties": {
-        "^[a-z A-Z 0-9]+$": {
+        "^[a-zA-Z0-9\\-_]+$": {
           "description": "Names of outputs",
           "patternProperties":{
             "^(0|([1-9][0-9]*))$" :{

--- a/APIs/schemas/map-tables-response-schema.json
+++ b/APIs/schemas/map-tables-response-schema.json
@@ -14,7 +14,7 @@
     },
     "map":{
       "patternProperties": {
-        "^[a-z A-Z 0-9]+$": {
+        "^[a-z A-Z 0-9 \\- _]+$": {
           "description": "Names of outputs",
           "patternProperties":{
             "^(0|([1-9][0-9]*))$":{

--- a/APIs/schemas/map-tables-response-schema.json
+++ b/APIs/schemas/map-tables-response-schema.json
@@ -14,7 +14,7 @@
     },
     "map":{
       "patternProperties": {
-        "^[a-z A-Z 0-9 \\- _]+$": {
+        "^[a-zA-Z0-9\\-_]+$": {
           "description": "Names of outputs",
           "patternProperties":{
             "^(0|([1-9][0-9]*))$":{

--- a/APIs/schemas/output-caps-response-schema.json
+++ b/APIs/schemas/output-caps-response-schema.json
@@ -13,7 +13,7 @@
           "string",
           "null"
         ],
-        "pattern": "^[a-z A-Z 0-9 \\- _]+$"
+        "pattern": "^[a-zA-Z0-9\\-_]+$"
       }
     }
   }

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -17,7 +17,7 @@ If the audio channel mapping behaviour of the Device is changed via another prot
 Inputs and Outputs are represented by a unique identifier. This identifier MUST conform to the following regex pattern:
 
 ```regex
-^[a-z A-Z 0-9 \- _]+$
+^[a-zA-Z0-9\-_]+$
 ```
 
 All Input and Output identifiers MUST be immutable. Two Inputs MUST NOT share an identifier. Two Outputs MUST NOT share an identifier.


### PR DESCRIPTION
* Update this input/output regex where it has been missed before
* Resolve regex issue raised in #7 
* Add a new schema for the root of input/output to clarify the restrictions on those IDs in the schema