### PR TITLE
changes associated with the newbury workshop january 2019.  Includes:

### DIFF
--- a/APIs/ChannelMappingAPI.raml
+++ b/APIs/ChannelMappingAPI.raml
@@ -26,7 +26,7 @@ documentation:
 /io:
   displayName: Input/Output view
   get:
-    responses: 
+    responses:
       200:
         body:
           example: !include ../examples/io-get-200.json
@@ -103,6 +103,17 @@ documentation:
           body:
             example: !include ../examples/map/map-tables-get-200.json
             type: !include schemas/map-tables-response-schema.json
+    /{outputId}:
+      displayName: subset of the active mapping resource related to the specified output
+      description: This resource allows a controller to fetch only the section of the map related to the named output, without the need to fetch the entire map.
+      get:
+        responses:
+          200:
+            body:
+              example: !include ../examples/map/map-activewithid-get-200.json
+              type: !include schemas/map-activewithid-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
 /inputs:
   displayName: Inputs
   get:
@@ -134,16 +145,16 @@ documentation:
       get:
         responses:
           200:
-            body: 
+            body:
               example: !include ../examples/inputs/input-name-parent-get-200.json
               type: !include schemas/input-parent-response-schema.json
           404:
             description: Returned when the requested resource does not exist
     /channels:
       get:
-        responses: 
+        responses:
           200:
-            body: 
+            body:
               example: !include ../examples/inputs/input-name-channels-get-200.json
               type: !include schemas/input-channels-response-schema.json
           404:
@@ -161,7 +172,7 @@ documentation:
   displayName: Outputs
   get:
     description: List all outputs available
-    responses: 
+    responses:
       200:
         body:
           example: !include ../examples/outputs/output-root-get-200.json
@@ -179,7 +190,7 @@ documentation:
           description: Returned when the requested resource does not exist
     /sourceid:
       get:
-        responses: 
+        responses:
           200:
             body:
               example: !include ../examples/outputs/output-name-sourceid-get-200.json
@@ -197,7 +208,7 @@ documentation:
             description: Returned when the requested resource does not exist
     /caps:
       get:
-        responses: 
+        responses:
           200:
             body:
               example: !include ../examples/outputs/output-name-caps-get-200.json

--- a/APIs/schemas/map-activations-activationid-get-response-schema.json
+++ b/APIs/schemas/map-activations-activationid-get-response-schema.json
@@ -9,35 +9,7 @@
       "$ref": "activation-response-schema.json"
     },
     "action:":{
-      "^[a-z A-Z 0-9 \\- _]+$": {
-        "description": "Names of outputs",
-        "patternProperties":{
-          "^(0|([1-9][0-9]*))$":{
-            "description": "Index of channels",
-            "required":[
-              "input",
-              "channel_index"
-            ],
-            "properties": {
-              "input":{
-                "description": "Name of the input the channel to be connected belongs to. null for disconnected.",
-                "pattern": "^[a-z A-Z 0-9 \\- _]+$",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "channel_index":{
-                "description": "Index of channel to be connected.",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            }
-          }
-        }
-      }
+      "$ref": "map-tableentry-schema.json"
     }
   }
 }

--- a/APIs/schemas/map-activations-get-response-schema.json
+++ b/APIs/schemas/map-activations-get-response-schema.json
@@ -12,35 +12,7 @@
           "$ref": "activation-response-schema.json"
         },
         "action:":{
-          "^[a-z A-Z 0-9 \\- _]+$": {
-            "description": "Names of outputs",
-            "patternProperties":{
-              "^(0|([1-9][0-9]*))$":{
-                "description": "Index of channels",
-                "required":[
-                  "input",
-                  "channel_index"
-                ],
-                "properties": {
-                  "input":{
-                    "description": "Name of the input the channel to be connected belongs to. null for disconnected.",
-                    "pattern": "^[a-z A-Z 0-9 \\- _]+$",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "channel_index":{
-                    "description": "Index of channel to be connected.",
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "map-tableentry-schema.json"
         }
       }
     }

--- a/APIs/schemas/map-activations-post-response-schema.json
+++ b/APIs/schemas/map-activations-post-response-schema.json
@@ -13,35 +13,7 @@
           "$ref": "activation-response-schema.json"
         },
         "action:":{
-          "^[a-z A-Z 0-9 \\- _]+$": {
-            "description": "Names of outputs",
-            "patternProperties":{
-              "^(0|([1-9][0-9]*))$":{
-                "description": "Index of channels",
-                "required":[
-                  "input",
-                  "channel_index"
-                ],
-                "properties": {
-                  "input":{
-                    "description": "Name of the input the channel to be connected belongs to. null for disconnected.",
-                    "pattern": "^[a-z A-Z 0-9 \\- _]+$",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "channel_index":{
-                    "description": "Index of channel to be connected.",
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "map-tableentry-schema.json"
         }
       }
     }

--- a/APIs/schemas/map-activations-request-schema.json
+++ b/APIs/schemas/map-activations-request-schema.json
@@ -9,35 +9,7 @@
       "$ref": "activation-schema.json"
     },
     "action:":{
-      "^[a-z A-Z 0-9 \\- _]+$": {
-        "description": "Names of outputs",
-        "patternProperties":{
-          "^(0|([1-9][0-9]*))$":{
-            "description": "Index of channels",
-            "required":[
-              "input",
-              "channel_index"
-            ],
-            "properties": {
-              "input":{
-                "description": "Name of the input the channel to be connected belongs to. null for disconnected.",
-                "pattern": "^[a-z A-Z 0-9 \\- _]+$",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "channel_index":{
-                "description": "Index of channel to be connected.",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            }
-          }
-        }
-      }
+      "$ref": "map-tableentry-schema.json"
     }
   }
 }

--- a/APIs/schemas/map-activewithid-response-schema.json
+++ b/APIs/schemas/map-activewithid-response-schema.json
@@ -1,13 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Describes the map table object",
+  "description": "Describes the map for one specific outputId",
   "title": "Map table resource",
-  "additionalProperties": false,
-  "required":[
-    "activation",
-    "map"
-  ],
   "properties": {
     "activation": {
       "$ref": "activation-response-schema.json"

--- a/APIs/schemas/map-tableentry-schema.json
+++ b/APIs/schemas/map-tableentry-schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes one map table entry",
+  "title": "Map table entry",
+  "patternProperties": {
+    "^[a-zA-Z0-9\\-_]+$": {
+      "description": "Names of the output",
+      "patternProperties":{
+        "^(0|([1-9][0-9]*))$":{
+          "description": "Index of channels",
+          "required":[
+            "input",
+            "channel_index"
+          ],
+          "properties": {
+            "input":{
+              "description": "Name of the input the channel to be connected belongs to. null for disconnected.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "channel_index":{
+              "description": "Index of channel to be connected.",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -2,7 +2,7 @@
 
 _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
-The Audio Channel Mapping API shares a data model with the NMOS IS-04 specification, and as a result it is designed to be used alongside it. The following implementation notes identify correct behaviour for doing this.
+The Audio Channel Mapping API shares a data model with the NMOS IS-04 specification, and as a result it is designed to be used alongside it. The following implementation notes identify correct behavior for doing this.
 
 When this API is used alongside IS-04 in a deployment, the IS-04 APIs should be operating at version 1.1 or greater in order to ensure full interoperability.
 
@@ -27,9 +27,9 @@ Note as above that the API version is included in the 'type', and in the 'href'.
 
 More details about multi-version support can be found in [5.0. Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Audio Channel Mapping API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. In either case, a separate 'control' endpoint for each Device's API instance MUST be advertised, even if the URI is the same.
+A given instance of the Audio Channel Mapping API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. In either case, the 'control' endpoint for each Device's audio channel mapping API instance MUST be advertised, even if the URI is the same.
 
-This flexibility is to accomodate different relationships between Devices and Nodes. For example, some Devices may be loosly coupled to the Node, for example cards in a card frame. These Devices are more likely to have an instance of the API for each card. Others may be tightly coupled, for example a media processing pipeline on a server, where it is likely to be preferable to have one instance of the API that is advertised for each pipeline.
+This flexibility is to accommodate different relationships between Devices and Nodes. For example, some Devices may be loosely coupled to the Node, for example cards in a card frame. These Devices are more likely to have an instance of the API for each card. Others may be tightly coupled, for example a media processing pipeline on a server, where it is likely to be preferable to have one instance of the API that is advertised for each pipeline.
 
 ## Receiver and Source IDs
 
@@ -39,4 +39,4 @@ Where this Device creates a new Source at an Output (see [4.0 Behaviour](4.0.%20
 
 ## Version Increments
 
-In order to prevent unnecessary polling of the Audio Channel Mapping API, any changes to active map parameters belonging to Source connected Outputs MUST be signalled via the IS-04 versioning mechanism by means of a version timestamp increment.
+In order to prevent unnecessary polling of the Audio Channel Mapping API active map resource, any changes to active map parameters belonging to Source connected Outputs MUST be signaled via the IS-04 versioning mechanism by means of a version timestamp increment on the related "source" object.  For active map parameters belonging to outputs which are not backed by an IS-04 registered source, the version timestamp of the related IS-04 device object should be updated.

--- a/examples/map/map-activewithid-get-200.json
+++ b/examples/map/map-activewithid-get-200.json
@@ -1,0 +1,12 @@
+{
+  "outB":{
+      "0":{
+        "input": "input4",
+        "channel_index": 0
+      },
+      "1":{
+        "input": "input4",
+        "channel_index": 1
+      }
+    }
+}


### PR DESCRIPTION
* adds GET /map/active/{outputId}
* adds text in ChannelMappingAPI.raml to describe the registry version 
notification method for non-source outputs
* refactors the map schemas to refer to a common entry definition for 
map tables