### PR TITLE
Input Source IDs

### DIFF
--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -46,7 +46,7 @@ In the case where no audio is currently mapped onto an Output (i.e all its entri
 
 ### Receiver / Source and Input Relationship
 
-When receiver audio from an NMOS Receiver the UUID of the Receiver SHOULD appear in the `id` field of the `parent` resource of the associated Input (e.g inputs/input1/parent). When the `parent` resource is populated with a Receiver ID, the `type` field SHALL be populated with the string `receiver`.
+When receiving audio from an NMOS Receiver the UUID of the Receiver SHOULD appear in the `id` field of the `parent` resource of the associated Input (e.g inputs/input1/parent). When the `parent` resource is populated with a Receiver ID, the `type` field SHALL be populated with the string `receiver`.
 
 ```json
 {

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -46,16 +46,7 @@ In the case where no audio is currently mapped onto an Output (i.e all its entri
 
 ### Receiver / Source and Input Relationship
 
-Where the audio associated with an Audio Channel Mapping API Input comes directly from an NMOS Receiver, the UUID of the originating Source SHOULD be populated in `id` field of the `parent` resource, and the `type` filed set to `source`. This information may be made available using in-stream identifiers, or some sidecar method of reception.
-
-```json
-{
-  "id": "bdec047b-d161-492a-9496-96da704de2b1",
-  "type": "source"
-}
-```
-
-If information about the Source ID is not available, then the UUID of the Receiver SHOULD appear in the `id` field of the `parent` resource of the associated Input (e.g inputs/input1/parent). When the `parent` resource is populated with a Receiver ID, the `type` field SHALL be populated with the string `receiver`.
+When receiver audio from an NMOS Receiver the UUID of the Receiver SHOULD appear in the `id` field of the `parent` resource of the associated Input (e.g inputs/input1/parent). When the `parent` resource is populated with a Receiver ID, the `type` field SHALL be populated with the string `receiver`.
 
 ```json
 {


### PR DESCRIPTION
Only receiver ID is needed in the parent resource when an input is connected to an NMOS receiver.

As suggested by @cristian-recoseanu