### PR TITLE
description in example file should be 2110-30 instead of 2110-20

### DIFF
--- a/examples/outputs/output-name-properties-get-200.json
+++ b/examples/outputs/output-name-properties-get-200.json
@@ -1,4 +1,4 @@
 {
     "name": "IP Output",
-    "description": "SMPTE 2110-20 IP Output"
+    "description": "SMPTE 2110-30 IP Output"
 }


### PR DESCRIPTION
As 2110-20 is video only, I guess we wanted to reference an ST2110-30 IP output