### PR TITLE
Output /sourceid and Input /parent

### DIFF
--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -30,23 +30,34 @@ These are distinct from the machine readable unique identifier.
 
 ### Output and Source Relationship
 
-The `sourceid` resource of an Output SHOULD be populated with a Source ID when audio is mapped to an Output, if:
+The `sourceid` resource of an Output SHOULD be populated with a Source ID, if:
 
-* It is or may be passed directly to an NMOS Sender within the same Device.
+* The output audio may be transmitted directly by an NMOS Sender within the Device.
 
-* It is or may be passed to another process within the Device which is capable of performing a transformation on the Source that would constitute a new Source and or Flow.
+* The output audio may be transformed by some process to create a new Source and/or Flow.
 
-* It is or may be passed to another process within the Device that would not constitute the creation of a new Source or Flow, but would or may then route its resultant output to an NMOS Sender.
+* The Output is routed back to an Input of the Channel Mapping API (see [Re-entrant Mappings](#re-entrant-mappings)).
 
-* It is routed back to the Input of the Channel Mapping API (see [Re-entrant Mappings](#re-entrant-mappings)).
+Otherwise, the `sourceid` MAY be set to `null`.
 
-Otherwise, the `sourceid` MUST be set to `null`.
-
-In the case where no audio is currently mapped onto an Output (i.e all its entries in the active map are `null`) then the Output still constitutes a Source, and as such the `sourceid` resource for the Output SHOULD still present a Source ID where it would otherwise be required to do so.
+In the case where no audio is currently routed to an Output (i.e all its entries in the active map are `null`) then the Output still constitutes a Source, and as such the `sourceid` resource for the Output SHOULD still present a Source ID where it would otherwise be required to do so.
 
 ### Receiver / Source and Input Relationship
 
-Where the audio associated with a Channel Mapping API Input comes directly from an NMOS Receiver, the UUID of the originating Source SHOULD be populated in `id` field of the `parent` resource, and the `type` field set to `source`. This information may be made available using in-stream identifiers or using some out-of-band method.
+Where the audio associated with a Channel Mapping API Input comes directly from an NMOS Receiver, then the `parent` resource of the Input is populated in one of two ways:
+
+* The ID of the originating Source SHOULD appear in the `id` field of the `parent resource if this information is available via some in-stream or out-of-band methods.
+
+* However, if information about the Source ID is not available, then the ID of the Receiver SHOULD appear in the `id` field of the `parent` resource.
+
+Where the received audio has undergone one or more Source-creating transformations between the Receiver and this Input, the `id` field of the `parent` resource SHOULD contain the ID of the immediate parent Source.
+
+On the other hand, if the Input does not have an associated NMOS Receiver or Source, the `id` field in the `parent` resource SHOULD be set to `null`.
+
+When the `id` contains a Source ID or Receiver ID, the `type` field MUST be populated with the string `source` or `receiver` as appropriate.
+When the `id` is `null`, the `type` field MUST also be populated with `null`.
+
+For example, the following are all valid:
 
 ```json
 {
@@ -54,8 +65,6 @@ Where the audio associated with a Channel Mapping API Input comes directly from 
   "type": "source"
 }
 ```
-
-If information about the Source ID is not available, then the UUID of the Receiver SHOULD appear in the `id` field of the `parent` resource of the associated Input (e.g inputs/input1/parent). When the `parent` resource is populated with a Receiver ID, the `type` field MUST be populated with the string `receiver`.
 
 ```json
 {
@@ -64,17 +73,6 @@ If information about the Source ID is not available, then the UUID of the Receiv
 }
 ```
 
-It is possible that received audio may have undergone one or more Source creating transformations between Receiver and the Channel Mapping API. In this case, the `id` field of the `parent` resource SHOULD contain the ID of the upstream Source. The `type` field should contain the string `source`.
-
-```json
-{
-  "id": "bdec047b-d161-492a-9496-96da704de2b1",
-  "type": "source"
-}
-```
-
-If the audio did not originate with an NMOS Receiver and has not yet been represented as an NMOS Source, both fields in the `parent` resource SHOULD be set to `null`.
-
 ```json
 {
  "id": null,
@@ -82,7 +80,7 @@ If the audio did not originate with an NMOS Receiver and has not yet been repres
 }
 ```
 
-In the case where an Input is not currently receiving any audio, but would pass any audio received in the future onto its Output, then the `parent` resource SHOULD be populated with the Receiver or Source ID it is associated with as it would if receiving audio. For example, if an NMOS Receiver is not currently receiving a stream, but would pass any audio it received in the future onto a Channel Mapping API Input, then that input's `parent` field should be populated as if it were currently receiving audio from that Receiver.
+The `parent` resource SHOULD be populated as specified even when the Input is not currently receiving audio from the parent Receiver or Source.
 
 ### Channels
 
@@ -288,7 +286,7 @@ And the re-entrant mapping is represented with `/map/active/aes67`:
 
 In this scenario the audio undergoes two distinct routing operations - the first from the MADI input to the MADI card, and then a second from the MADI card to the AES67 output. In order to allow for these kinds of restrictions the Channel Mapping API supports re-entrant mappings, in which audio at an Output may be routed back to an Input. This is signaled to the control system by the same Source ID being present in both the Output's `sourceid` resource and also the Input's `parent` resource.
 
-Where this is done the Device MUST ensure that the Output constraints prevents audio being routed such that a loop is formed, which is to say audio must not be able to be routed back to the Output from which it originated.
+Where this is done the Device MUST ensure that the Output constraints prevent audio being routed such that a loop is formed, which is to say audio must not be able to be routed back to the Output from which it originated.
 
 ## IO Resource
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -32,7 +32,7 @@ These are distinct from the machine readable unique identifier.
 
 The `sourceid` resource of an Output SHOULD be populated with a Source ID, if:
 
-* The output audio may be transmitted directly by an NMOS Sender within the Device.
+* The output audio may be transmitted directly by an NMOS Sender belonging to the Device.
 
 * The output audio may be transformed by some process to create a new Source and/or Flow.
 
@@ -46,7 +46,7 @@ In the case where no audio is currently routed to an Output (i.e all its entries
 
 Where the audio associated with a Channel Mapping API Input comes directly from an NMOS Receiver, then the `parent` resource of the Input is populated in one of two ways:
 
-* The ID of the originating Source SHOULD appear in the `id` field of the `parent resource if this information is available via some in-stream or out-of-band methods.
+* The ID of the originating Source SHOULD appear in the `id` field of the `parent` resource if this information is available via some in-stream or out-of-band method.
 
 * However, if information about the Source ID is not available, then the ID of the Receiver SHOULD appear in the `id` field of the `parent` resource.
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -80,7 +80,7 @@ For example, the following are all valid:
 }
 ```
 
-The `parent` resource SHOULD be populated as specified even when the Input is not currently receiving audio from the parent Receiver or Source.
+The `parent` resource MUST be populated as specified even when the Input is not currently receiving audio from the parent Receiver or Source.
 
 ### Channels
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -286,7 +286,7 @@ And the re-entrant mapping is represented with `/map/active/aes67`:
 
 In this scenario the audio undergoes two distinct routing operations - the first from the MADI input to the MADI card, and then a second from the MADI card to the AES67 output. In order to allow for these kinds of restrictions the Channel Mapping API supports re-entrant mappings, in which audio at an Output may be routed back to an Input. This is signaled to the control system by the same Source ID being present in both the Output's `sourceid` resource and also the Input's `parent` resource.
 
-Where this is done the Device MUST ensure that the Output constraints prevent audio being routed such that a loop is formed, which is to say audio must not be able to be routed back to the Output from which it originated.
+Where this is done, Output constraints MUST prevent audio being routed back to the Output from which it originated.
 
 ## IO Resource
 


### PR DESCRIPTION
**Source ID**

We think the intent is if the Output's audio will be used by an NMOS entity as the next step, then it needs a Source ID, otherwise the ability to trace it through the system is lost. If it's being passed to a non-NMOS thing then the Source ID may get lost anyway so there may be no need for it.

**Parent**

We think the preference for Source ID rather than Receiver ID was intended to match up with the mechanism provided by IS-04 Source `parents` and ancestry queries in the Query API. However, there's currently no scalable way to obtain the Source/Flow information from the Sender.

This PR is intended to clarify these rationale and requirements.