### PR TITLE
Re-order RAML endpoints for a consistent story

### DIFF
--- a/APIs/ChannelMappingAPI.raml
+++ b/APIs/ChannelMappingAPI.raml
@@ -24,16 +24,140 @@ documentation:
         body:
           example: !include ../examples/base-get-200.json
           type: !include schemas/base-schema.json
-/io:
-  displayName: Input/Output view
+/inputs:
+  displayName: Inputs
   get:
-    description: Get a view on all Inputs and Outputs
+    description: List all inputs available
     responses:
       200:
         body:
-          example: !include ../examples/io-get-200.json
-          type: !include schemas/io-response-schema.json
-
+          example: !include ../examples/inputs/inputs-base-get-200.json
+          type: !include schemas/inputs-outputs-base-schema.json
+  /{inputId}:
+    uriParameters:
+      inputId:
+        type: string
+        pattern: "^[a-zA-Z0-9\\-_]+$"
+    get:
+      description: List of paths available from this API endpoint
+      responses:
+        200:
+          body:
+            example: !include ../examples/inputs/input-base-get-200.json
+            type: !include schemas/input-base-schema.json
+        404:
+          description: Returned when the requested resource does not exist
+    /properties:
+      displayName: Input Properties
+      get:
+        description: Get information about the specified Input, such as a human-readable name and description
+        responses:
+          200:
+            body:
+              example: !include ../examples/inputs/input-properties-get-200.json
+              type: !include schemas/input-properties-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+    /parent:
+      displayName: Input Parent
+      get:
+        description: Get information about the origin of the audio associated with the specified Input
+        responses:
+          200:
+            body:
+              example: !include ../examples/inputs/input-parent-get-200.json
+              type: !include schemas/input-parent-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+    /channels:
+      displayName: Input Channels
+      get:
+        description: Get information about the specified Input's channels, such as human-readable labels
+        responses:
+          200:
+            body:
+              example: !include ../examples/inputs/input-channels-get-200.json
+              type: !include schemas/input-channels-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+    /caps:
+      displayName: Input Capabilities
+      get:
+        description: Get information about the specified Input's capabilities, such as routing constraints
+        responses:
+          200:
+            body:
+              example: !include ../examples/inputs/input-caps-get-200.json
+              type: !include schemas/input-caps-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+/outputs:
+  displayName: Outputs
+  get:
+    description: List all outputs available
+    responses:
+      200:
+        body:
+          example: !include ../examples/outputs/outputs-base-get-200.json
+          type: !include schemas/inputs-outputs-base-schema.json
+  /{outputId}:
+    uriParameters:
+      outputId:
+        type: string
+        pattern: "^[a-zA-Z0-9\\-_]+$"
+    get:
+      description: List of paths available from this API endpoint
+      responses:
+        200:
+          body:
+            example: !include ../examples/outputs/output-base-get-200.json
+            type: !include schemas/output-base-schema.json
+        404:
+          description: Returned when the requested resource does not exist
+    /properties:
+      displayName: Output Properties
+      get:
+        description: Get information about the specified Output, such as a human-readable name and description
+        responses:
+          200:
+            body:
+              example: !include ../examples/outputs/output-properties-get-200.json
+              type: !include schemas/output-properties-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+    /sourceid:
+      displayName: Output Source ID
+      get:
+        description: Get the ID of the Source associated with the specified Output
+        responses:
+          200:
+            body:
+              example: !include ../examples/outputs/output-sourceid-get-200.json
+              type: !include schemas/output-sourceid-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+    /channels:
+      displayName: Output Channels
+      get:
+        description: Get information about the specified Output's channels, such as human-readable labels
+        responses:
+          200:
+            body:
+              example: !include ../examples/outputs/output-channels-get-200.json
+              type: !include schemas/output-channels-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
+    /caps:
+      displayName: Output Capabilities
+      get:
+        description: Get information about the specified Output's capabilities, such as routing constraints
+        responses:
+          200:
+            body:
+              example: !include ../examples/outputs/output-caps-get-200.json
+              type: !include schemas/output-caps-response-schema.json
+          404:
+            description: Returned when the requested resource does not exist
 /map:
   displayName: Map
   get:
@@ -139,137 +263,12 @@ documentation:
               type: !include schemas/map-active-output-response-schema.json
           404:
             description: Returned when the requested resource does not exist
-/inputs:
-  displayName: Inputs
+/io:
+  displayName: Inputs/Outputs View
   get:
-    description: List all inputs available
+    description: Get a view on all Inputs and Outputs
     responses:
       200:
         body:
-          example: !include ../examples/inputs/inputs-base-get-200.json
-          type: !include schemas/inputs-outputs-base-schema.json
-  /{inputId}:
-    uriParameters:
-      inputId:
-        type: string
-        pattern: "^[a-zA-Z0-9\\-_]+$"
-    get:
-      description: List of paths available from this API endpoint
-      responses:
-        200:
-          body:
-            example: !include ../examples/inputs/input-base-get-200.json
-            type: !include schemas/input-base-schema.json
-        404:
-          description: Returned when the requested resource does not exist
-    /caps:
-      displayName: Input Capabilities
-      get:
-        description: Get information about the specified Input's capabilities, such as routing constraints
-        responses:
-          200:
-            body:
-              example: !include ../examples/inputs/input-caps-get-200.json
-              type: !include schemas/input-caps-response-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-    /parent:
-      displayName: Input Parent
-      get:
-        description: Get information about the origin of the audio associated with the specified Input
-        responses:
-          200:
-            body:
-              example: !include ../examples/inputs/input-parent-get-200.json
-              type: !include schemas/input-parent-response-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-    /channels:
-      displayName: Input Channels
-      get:
-        description: Get information about the specified Input's channels, such as human-readable labels
-        responses:
-          200:
-            body:
-              example: !include ../examples/inputs/input-channels-get-200.json
-              type: !include schemas/input-channels-response-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-    /properties:
-      displayName: Input Properties
-      get:
-        description: Get information about the specified Input, such as a human-readable name and description
-        responses:
-          200:
-            body:
-              example: !include ../examples/inputs/input-properties-get-200.json
-              type: !include schemas/input-properties-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-/outputs:
-  displayName: Outputs
-  get:
-    description: List all outputs available
-    responses:
-      200:
-        body:
-          example: !include ../examples/outputs/outputs-base-get-200.json
-          type: !include schemas/inputs-outputs-base-schema.json
-  /{outputId}:
-    uriParameters:
-      outputId:
-        type: string
-        pattern: "^[a-zA-Z0-9\\-_]+$"
-    get:
-      description: List of paths available from this API endpoint
-      responses:
-        200:
-          body:
-            example: !include ../examples/outputs/output-base-get-200.json
-            type: !include schemas/output-base-schema.json
-        404:
-          description: Returned when the requested resource does not exist
-    /sourceid:
-      displayName: Output Source ID
-      get:
-        description: Get the ID of the Source associated with the specified Output
-        responses:
-          200:
-            body:
-              example: !include ../examples/outputs/output-sourceid-get-200.json
-              type: !include schemas/output-sourceid-response-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-    /channels:
-      displayName: Output Channels
-      get:
-        description: Get information about the specified Output's channels, such as human-readable labels
-        responses:
-          200:
-            body:
-              example: !include ../examples/outputs/output-channels-get-200.json
-              type: !include schemas/output-channels-response-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-    /caps:
-      displayName: Output Capabilities
-      get:
-        description: Get information about the specified Output's capabilities, such as routing constraints
-        responses:
-          200:
-            body:
-              example: !include ../examples/outputs/output-caps-get-200.json
-              type: !include schemas/output-caps-response-schema.json
-          404:
-            description: Returned when the requested resource does not exist
-    /properties:
-      displayName: Output Properties
-      get:
-        description: Get information about the specified Output, such as a human-readable name and description
-        responses:
-          200:
-            body:
-              example: !include ../examples/outputs/output-properties-get-200.json
-              type: !include schemas/output-properties-schema.json
-          404:
-            description: Returned when the requested resource does not exist
+          example: !include ../examples/io-get-200.json
+          type: !include schemas/io-response-schema.json

--- a/APIs/schemas/input-base-schema.json
+++ b/APIs/schemas/input-base-schema.json
@@ -6,10 +6,10 @@
   "items": {
     "type": "string",
     "enum": [
-      "caps/",
+      "properties/",
       "parent/",
       "channels/",
-      "properties/"
+      "caps/"
     ]
   },
   "minItems": 4,

--- a/APIs/schemas/io-response-schema.json
+++ b/APIs/schemas/io-response-schema.json
@@ -15,6 +15,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "properties":{
+              "$ref": "input-properties-schema.json"
+            },
             "parent":{
               "$ref": "input-parent-response-schema.json"
             },
@@ -23,9 +26,6 @@
             },
             "caps":{
               "$ref": "input-caps-response-schema.json"
-            },
-            "properties":{
-              "$ref": "input-properties-schema.json"
             }
           }
         }
@@ -38,6 +38,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "properties":{
+              "$ref": "output-properties-schema.json"
+            },
             "source_id":{
               "$ref": "output-sourceid-response-schema.json"
             },
@@ -46,9 +49,6 @@
             },
             "caps":{
               "$ref": "output-caps-response-schema.json"
-            },
-            "properties":{
-              "$ref": "output-properties-schema.json"
             }
           }
         }

--- a/APIs/schemas/output-base-schema.json
+++ b/APIs/schemas/output-base-schema.json
@@ -6,10 +6,10 @@
   "items": {
     "type": "string",
     "enum": [
+      "properties/",
       "sourceid/",
       "channels/",
-      "caps/",
-      "properties/"
+      "caps/"
     ]
   },
   "minItems": 4,

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -87,25 +87,25 @@ The API is divided into the following parts:
 
 ### Inputs
 
-This resource and its child resources enumerate all of the Inputs, their channels and routing constraints. It also exposes the `parent` resource, which is used to indicate the origin of the audio associated with that Input.
+The `inputs` resource and its child resources enumerate all of the Inputs, their channels and routing constraints. It also exposes the `parent` resource, which is used to indicate the origin of the audio associated with that Input.
 
 These resources are read only.
 
 ### Outputs
 
-This resource and its child resources enumerate all of the Outputs, including restrictions on which Inputs may be routed to an Output, and an optional Source ID, which represents the new NMOS Source created by re-mapping the audio.
+The `outputs` resource and its child resources enumerate all of the Outputs, including restrictions on which Inputs may be routed to an Output, and an optional Source ID, which represents the new NMOS Source created by re-mapping the audio.
 
 These resources are read only.
 
-### IO
-
-This resource is simply a view onto data available elsewhere in the API, in order to allow clients to gather the information they need about inputs and outputs in a single request.
-
-This resource is read only.
-
 ### Map
 
-This resource has child resources that represent the Active Map and any pending Activations. The Active Map is not directly modifiable by the client - changes must be made by POSTing Activations.
+The `map` resource has child resources that represent the Active Map and any pending Activations. The Active Map is not directly modifiable by the client - changes must be made by POSTing Activations.
+
+### Inputs/Outputs View
+
+The `io` resource is simply a view onto data available elsewhere in the API, in order to allow clients to gather the information they need about inputs and outputs in a single request.
+
+This resource is read only.
 
 ## API Interaction
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -12,6 +12,8 @@ If the audio channel mapping behaviour of the Device is changed via another prot
 
 ## Inputs and Outputs
 
+The `inputs` and `outputs` resources enumerate the Inputs and Outputs respectively. Each Input and Output resource has a number of child resources.
+
 ### Identifiers
 
 Inputs and Outputs are represented by a unique identifier. This identifier MUST conform to the following regex pattern:
@@ -164,7 +166,9 @@ Clients SHOULD NOT attempt to route channels from Inputs to an Output unless tha
 
 ## Map
 
-### The Map Structure
+The `map` resource has child resources that represent the Active Map and any pending Activations.
+
+### The Active Map
 
 The `active` resource contain a structure called `map`, which looks like the following:
 
@@ -288,8 +292,8 @@ In this scenario the audio undergoes two distinct routing operations - the first
 
 Where this is done, Output constraints MUST prevent audio being routed back to the Output from which it originated.
 
-## IO Resource
+## Inputs/Outputs View
 
-The IO resource provides a structure detailing all Inputs, Outputs and available mappings between them.
+The `io` resource provides a single response detailing all Inputs, Outputs and available mappings between them.
 
 The object returned from this resource contains an `inputs` object and an `outputs` object. These two objects contain objects representing each of the Inputs and Outputs. Each Input and Output object MUST contain properties corresponding to the child resources described in [Inputs and Outputs](#inputs-and-outputs), with matching values.


### PR DESCRIPTION
The documentation introduces Inputs and Outputs first, then the Map and the Inputs/Outputs View.
For each Input and Output it introduces the human-readable `properties`, describes the associated `parent` or `sourceid`, and then the `channels` information and the `caps` constraints.

The RAML has used different orders for Input and Output child resources due to incremental development (pre-v1.0), for example, the renaming in https://github.com/AMWA-TV/nmos-audio-channel-mapping/commit/be9679d17c9c58f6a2f2fffba013a629b25444fd#diff-29bf558f65cf1f8dbbcf44ca6eca6ad8.

This commit makes the ordering consistent throughout the RAML, schemas and docs.