### PR TITLE
Clarify that API reflects underlying Device always, not just at start-up

### DIFF
--- a/docs/Behaviour.md
+++ b/docs/Behaviour.md
@@ -8,7 +8,7 @@ _(c) AMWA 2018, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Start-Up Behaviour
 
-This specification does not define the channel mapping behaviour at start-up, as this may depend on the nature of the Device the API is controlling. However, it is important that the channel mapping behaviour of the underlying Device is reflected in the API at start-up.
+This specification does not define the channel mapping behaviour at start-up, as this may depend on the nature of the Device the API is controlling. It is important that the API always reflects the current channel mapping behaviour of the underlying Device.
 
 ## Interaction with Other Protocols
 

--- a/docs/Behaviour.md
+++ b/docs/Behaviour.md
@@ -8,7 +8,7 @@ _(c) AMWA 2018, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Start-Up Behaviour
 
-This specification does not define the channel mapping behaviour at start-up, as this may depend on the nature of the Device the API is controlling. It is important that the API always reflects the current channel mapping behaviour of the underlying Device.
+This specification does not define the channel mapping behaviour at start-up, as this may depend on the nature of the Device the API is controlling. It is important that the API always reflect the current channel mapping behaviour of the underlying Device.
 
 ## Interaction with Other Protocols
 
@@ -228,7 +228,7 @@ See the [Timestamps](#Timestamps) section for more details on the required inter
 
 Once an activation has been completed the resulting changes to the map MUST be reflected in the `active` endpoint. The `activation` object in the `active` endpoint MUST contain the details of the last activation to have taken place.
 
-Changes to the underlying Device's channel mapping behaviour (whether initiated by IS-08 or not) are reflected immediately into the Active Map `map`. Therefore the action of the most recent `activation` (or any previous activation) can have been overwritten. The only certain way to determine if the current behaviour is what the Client requires is to examine the `map`.
+Changes to the underlying Device's channel mapping behaviour (whether initiated by IS-08 or not) are reflected immediately into the Active Map `map`. Therefore the action of the most recent `activation` (or any previous activation) could have been overwritten. The only certain way to determine if the current behaviour is what the Client requires is to examine the `map`.
 
 #### Activation Responses
 

--- a/docs/Behaviour.md
+++ b/docs/Behaviour.md
@@ -228,6 +228,8 @@ See the [Timestamps](#Timestamps) section for more details on the required inter
 
 Once an activation has been completed the resulting changes to the map MUST be reflected in the `active` endpoint. The `activation` object in the `active` endpoint MUST contain the details of the last activation to have taken place.
 
+Changes to the underlying Device's channel mapping behaviour (whether initiated by IS-08 or not) are reflected immediately into the Active Map `map`. Therefore the action of the most recent `activation` (or any previous activation) can have been overwritten. The only certain way to determine if the current behaviour is what the Client requires is to examine the `map`.
+
 #### Activation Responses
 
 Each successful activation request is allocated a unique identifier by the API. This identifier MUST be unique within an API instance and for all time.


### PR DESCRIPTION
Resolves #63.
